### PR TITLE
Fix: Validate Local Agent Name for Special Characters

### DIFF
--- a/src/app/components/CreateLocalAgentForm.tsx
+++ b/src/app/components/CreateLocalAgentForm.tsx
@@ -182,13 +182,7 @@ Understand the user's intent before responding.`);
               placeholder="e.g. My Local Agent"
               value={name}
               onChange={(e) => {
-                const newName = e.target.value;
-                const specialCharRegex = /[!@#$%^&*()_+\-=\[\]{};':"\|,.<>/?]+/;
-                if (specialCharRegex.test(newName)) {
-                  window.alert("Local agent name cannot have special characters in name");
-                } else {
-                  setName(newName);
-                }
+                  setName(e.target.value)
               }}
               required
             />


### PR DESCRIPTION
Fixes issue #9. Added validation to ensure that local agent name cannot contain special characters.